### PR TITLE
feat: add decorator for timing function calls

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,7 +35,7 @@ repos:
     hooks:
       - id: interrogate
         exclude: (__init__.py|tests/.*|docs/.*)
-        args: [--fail-under=75]
+        args: [--fail-under=50]
 
   - repo: https://github.com/tox-dev/pyproject-fmt
     rev: v2.4.3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,7 +35,7 @@ repos:
     hooks:
       - id: interrogate
         exclude: (__init__.py|tests/.*|docs/.*)
-        args: [--fail-under=50]
+        args: [--fail-under=80, --ignore-nested-functions, --ignore-init-module]
 
   - repo: https://github.com/tox-dev/pyproject-fmt
     rev: v2.4.3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,6 +35,7 @@ repos:
     hooks:
       - id: interrogate
         exclude: (__init__.py|tests/.*|docs/.*)
+        args: [--fail-under=75]
 
   - repo: https://github.com/tox-dev/pyproject-fmt
     rev: v2.4.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,23 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.2.0] - 2025-01-09
+
+### Added
+
+- Decorator function `@basicbenchmark` (@rhkarls, PR #1)
+
+### Changed
+
+- Updated README.md with usage examples (@rhkarls, part of PR #1)
+- Added the return value of the function that is timed to the dictionary returned by benchmark_stats  (@rhkarls, part of PR #1 to enable decorator wrapping benchmark_stats)
+
+## [0.1.1] - 2024-12-12
+
+First public release of basicbenchmark.

--- a/README.md
+++ b/README.md
@@ -7,11 +7,12 @@
 
 basicbenchmark is a simple benchmarking tool for timing Python callables.
 
-It's so basic, that probably you don't need it. But if you do, here it is.
+It's so basic, that probably you don't need it. But if it saves you a moment, here it is.
+
 It runs a callable a number of times and returns the average time it took.
 Optionally, you can also get some basic statistics: fastest and slowest run time, and the standard deviation.
 
-No dependencies, just a simple wrapper around python standard library `timeit.Timer` and `time.perf_counter`.
+No dependencies, just a simple wrapper around Python standard library `timeit.Timer` and `time.perf_counter`.
 
 ## Installation
 
@@ -21,16 +22,56 @@ pip install basicbenchmark
 
 ## Usage
 
-The package provides two functions: `benchmark` and `benchmark_stats`.
+The package provides a decorator function, `basicbenchmark`, that can be used to time functions each time they are called.
+
+In addition, there are two functions that can be called directly: `benchmark` and `benchmark_stats`.
+These are useful for timing functions, keeping timing benchmarks separate from source code and storing the results in variables.
+
+### Decorator
+
+Add the `@basicbenchmark` decorator to a function to time the execution and write the results to the console.
+
+```python
+from basicbenchmark import basicbenchmark
+
+@basicbenchmark
+def my_function(x, y=2):
+    return x**y
+
+result = my_function(x=2) # result is 4
+
+my_function: 1 runs, mean time per run: 2.50 µs.
+```
+
+You can specify the number of runs to perform by passing the `n_runs` argument to the decorator.
+It will in addition print the fastest and slowest run times, along with the standard deviation.
+
+```python
+@basicbenchmark(n_runs=100_000)
+def my_function(x, y=2):
+    return x**y
+
+result = my_function(x=2) # result is 4
+my_function: 100,000 runs, mean time per run: 385.44±700.90 ns.
+	Fastest run: 200.00 ns. Slowest run: 123700.00 ns.
+```
+
+You can also pass the `pre_run=True` argument to the decorator, which will run the function once before starting the benchmark.
+This is useful for correctly timing JIT compiled functions, for example.
+
+### Benchmarking functions
+The two functions that can be called directly, `benchmark` and `benchmark_stats`, are used to time a callable and return the timing results.
 
 The `benchmark` function takes a callable, optional arguments and keyword arguments, and runs it a number of times, returning only the average time it took to run the callable in seconds.
 It supports auto ranging the number of runs to get an accurate result, as it is a wrapper around `timeit.Timer`, or you can specify the number of runs yourself with the `n_runs` argument.
 
-The `benchmark_stats` function takes the same input arguments as `benchmark`, but instead return a dictionary with the average time, the standard deviation, the fastest and the slowest time in seconds.
+The `benchmark_stats` function takes the same input arguments as `benchmark`, but instead return a dictionary with timing results and the function return value.
+The result dictionary contains the average time, the standard deviation, the fastest and the slowest time in seconds.
 This is useful if you want to know more about the distribution of the times it took to run the callable, and not just the average. In some cases the fastest time is of more interest than the average.
 
 Both functions print the results to the console in more readable time units, but this can be disabled by setting the `print_result` argument to `False`.
 Both functions also support a `pre_run` argument, which runs the callable once before performing the benchmark. Useful for example when calling JIT compiled functions.
+
 
 ```python
 from basicbenchmark import benchmark, benchmark_stats

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ pip install basicbenchmark
 
 ## Usage
 
-The package provides a decorator function, `basicbenchmark`, that can be used to time functions each time they are called.
+The package provides a decorator function, `@basicbenchmark`, that can be used to time functions each time they are called.
 
 In addition, there are two functions that can be called directly: `benchmark` and `benchmark_stats`.
 These are useful for timing functions, keeping timing benchmarks separate from source code and storing the results in variables.
@@ -66,12 +66,11 @@ The `benchmark` function takes a callable, optional arguments and keyword argume
 It supports auto ranging the number of runs to get an accurate result, as it is a wrapper around `timeit.Timer`, or you can specify the number of runs yourself with the `n_runs` argument.
 
 The `benchmark_stats` function takes the same input arguments as `benchmark`, but instead return a dictionary with timing results and the function return value.
-The result dictionary contains the average time, the standard deviation, the fastest and the slowest time in seconds.
+The timing results in the dictionary include the average time, the standard deviation, the fastest and the slowest time in seconds.
 This is useful if you want to know more about the distribution of the times it took to run the callable, and not just the average. In some cases the fastest time is of more interest than the average.
 
 Both functions print the results to the console in more readable time units, but this can be disabled by setting the `print_result` argument to `False`.
 Both functions also support a `pre_run` argument, which runs the callable once before performing the benchmark. Useful for example when calling JIT compiled functions.
-
 
 ```python
 from basicbenchmark import benchmark, benchmark_stats
@@ -94,17 +93,21 @@ To also get some basic statistics, use the `benchmark_stats` function. This func
 The example below uses the `benchmark_stats` with keyword arguments to pass to the callable:
 
 ```python
-timing_stats = benchmark_stats(my_function, kwargs={'x': 100, 'y': 3}, n_runs=100_000)
+benchmark_result = benchmark_stats(my_function, kwargs={'x': 100, 'y': 3}, n_runs=100_000)
 ```
 
 It returns the following dictionary:
 ```python
-timing_stats
-{'mean': 1.5315201089833864e-07, 'stdev': 5.44664144321298e-07, 'min': 9.998620953410864e-08, 'max': 0.00013040000339969993}
+benchmark_result
+{'return_value': 1000000,
+ 'mean': 2.2017200006757777e-07,
+ 'stdev': 1.883448346591418e-05,
+ 'min': 9.999985195463523e-08,
+ 'max': 0.005955899999662506}
 ```
 
 And prints to console:
 ```
-my_function: 100,000 runs, mean time per run: 153.15±544.66 ns.
-Fastest run: 99.99 ns. Slowest run: 130400.00 ns.
+my_function: 100,000 runs, mean time per run: 220.17±18834.48 ns.
+	Fastest run: 100.00 ns. Slowest run: 5955900.00 ns.
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires = [ "hatchling" ]
 
 [project]
 name = "basicbenchmark"
-version = "0.2.0-dev"
+version = "0.2.0-dev0"
 description = "A very simple and basic benchmarking tool for timing functions."
 readme = "README.md"
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires = [ "hatchling" ]
 
 [project]
 name = "basicbenchmark"
-version = "0.2.0-dev0"
+version = "0.2.0-dev1"
 description = "A very simple and basic benchmarking tool for timing functions."
 readme = "README.md"
 license = "MIT"
@@ -62,3 +62,18 @@ exclude = [ # don't report on checks for these
   '\\.__repr__$',
   '\\.__str__$',
 ]
+
+[tool.interrogate]
+ignore-init-method = false
+ignore-init-module = true
+ignore-magic = false
+ignore-semiprivate = false
+ignore-private = false
+ignore-property-decorators = false
+ignore-module = false
+ignore-nested-functions = true
+ignore-nested-classes = false
+ignore-setters = false
+ignore-overloaded-functions = false
+fail-under = 80
+exclude = [ "tests" ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires = [ "hatchling" ]
 
 [project]
 name = "basicbenchmark"
-version = "0.2.0-dev1"
+version = "0.2.0"
 description = "A very simple and basic benchmarking tool for timing functions."
 readme = "README.md"
 license = "MIT"

--- a/src/basicbenchmark/__init__.py
+++ b/src/basicbenchmark/__init__.py
@@ -2,5 +2,6 @@ import importlib.metadata
 
 from basicbenchmark.benchmark import benchmark as benchmark
 from basicbenchmark.benchmark import benchmark_stats as benchmark_stats
+from basicbenchmark.decorators import benchmark_stats_me as benchmark_stats_me
 
 __version__ = importlib.metadata.version("basicbenchmark")

--- a/src/basicbenchmark/__init__.py
+++ b/src/basicbenchmark/__init__.py
@@ -2,6 +2,6 @@ import importlib.metadata
 
 from basicbenchmark.benchmark import benchmark as benchmark
 from basicbenchmark.benchmark import benchmark_stats as benchmark_stats
-from basicbenchmark.decorators import benchmark_stats_me as benchmark_stats_me
+from basicbenchmark.decorators import basicbenchmark as basicbenchmark
 
 __version__ = importlib.metadata.version("basicbenchmark")

--- a/src/basicbenchmark/benchmark.py
+++ b/src/basicbenchmark/benchmark.py
@@ -83,7 +83,7 @@ def benchmark_stats(
     print_result: bool = True,
     n_runs: Optional[int] = None,
     pre_run: bool = False,
-) -> tuple[dict[str, Union[float, None]], Any]:
+) -> dict[str, float | None | Any]:
     """
     A simple time benchmark for a callable with basic statistics.
 
@@ -105,10 +105,12 @@ def benchmark_stats(
     Returns
     -------
     dict
-        A dictionary with the mean, standard deviation, minimum (fastest) and maximum (slowest) run
-        times of `n_runs` calls of `func` in seconds.
-    any
-        The return value from the func Callable.
+        A dictionary with the following keys:
+            - return_value: the callable return value.
+            - mean: the average time of `n_runs` calls of `func` in seconds.
+            - stdev: standard deviation time of `n_runs` calls of `func` in seconds.
+            - min: minimum (fastest) time of all `n_runs` calls of `func` in seconds.
+            - max: maximum (slowest) time of all `n_runs` calls of `func` in seconds.
     """
 
     return_value = None
@@ -151,11 +153,12 @@ def benchmark_stats(
         print(print_str)
 
     return {
+        "return_value": return_value,
         "mean": mean_time,
         "stdev": stdev_time,
         "min": min_time,
         "max": max_time,
-    }, return_value
+    }
 
 
 def _print_time_benchmark(

--- a/src/basicbenchmark/benchmark.py
+++ b/src/basicbenchmark/benchmark.py
@@ -11,12 +11,12 @@ Will output standard deviation of all runs, fastest single run and slowest singl
 import statistics
 import time
 import timeit
-from typing import Callable, Optional, Union
+from typing import Any, Callable, Optional
 
 
 def benchmark(
     func: Callable,
-    args: Optional[list] = None,
+    args: Optional[list | tuple] = None,
     kwargs: Optional[dict] = None,
     print_result: bool = True,
     n_runs: Optional[int] = None,
@@ -78,12 +78,12 @@ def benchmark(
 
 def benchmark_stats(
     func: Callable,
-    args: Optional[list] = None,
+    args: Optional[list | tuple] = None,
     kwargs: Optional[dict] = None,
     print_result: bool = True,
     n_runs: Optional[int] = None,
     pre_run: bool = False,
-) -> dict[str, Optional[Union[int, float]]]:
+) -> tuple[dict[str, float | None], Any]:
     """
     A simple time benchmark for a callable with basic statistics.
 
@@ -107,8 +107,11 @@ def benchmark_stats(
     dict
         A dictionary with the mean, standard deviation, minimum (fastest) and maximum (slowest) run
         times of `n_runs` calls of `func` in seconds.
+    any
+        The return value from the func Callable.
     """
 
+    return_value = None
     times = []
 
     if kwargs is None:
@@ -125,7 +128,7 @@ def benchmark_stats(
 
     for _ in range(n_runs):
         t_start = time.perf_counter()
-        func(*args, **kwargs)
+        return_value = func(*args, **kwargs)
         times.append(time.perf_counter() - t_start)
 
     mean_time = statistics.mean(times)
@@ -147,7 +150,12 @@ def benchmark_stats(
         )
         print(print_str)
 
-    return {"mean": mean_time, "stdev": stdev_time, "min": min_time, "max": max_time}
+    return {
+        "mean": mean_time,
+        "stdev": stdev_time,
+        "min": min_time,
+        "max": max_time,
+    }, return_value
 
 
 def _print_time_benchmark(

--- a/src/basicbenchmark/benchmark.py
+++ b/src/basicbenchmark/benchmark.py
@@ -11,12 +11,12 @@ Will output standard deviation of all runs, fastest single run and slowest singl
 import statistics
 import time
 import timeit
-from typing import Any, Callable, Optional
+from typing import Any, Callable, Optional, Union
 
 
 def benchmark(
     func: Callable,
-    args: Optional[list | tuple] = None,
+    args: Optional[Union[list, tuple]] = None,
     kwargs: Optional[dict] = None,
     print_result: bool = True,
     n_runs: Optional[int] = None,
@@ -78,12 +78,12 @@ def benchmark(
 
 def benchmark_stats(
     func: Callable,
-    args: Optional[list | tuple] = None,
+    args: Optional[Union[list, tuple]] = None,
     kwargs: Optional[dict] = None,
     print_result: bool = True,
     n_runs: Optional[int] = None,
     pre_run: bool = False,
-) -> tuple[dict[str, float | None], Any]:
+) -> tuple[dict[str, Union[float, None]], Any]:
     """
     A simple time benchmark for a callable with basic statistics.
 

--- a/src/basicbenchmark/benchmark.py
+++ b/src/basicbenchmark/benchmark.py
@@ -83,7 +83,7 @@ def benchmark_stats(
     print_result: bool = True,
     n_runs: Optional[int] = None,
     pre_run: bool = False,
-) -> dict[str, float | None | Any]:
+) -> dict[str, Union[float, None, Any]]:
     """
     A simple time benchmark for a callable with basic statistics.
 

--- a/src/basicbenchmark/benchmark.py
+++ b/src/basicbenchmark/benchmark.py
@@ -207,7 +207,7 @@ def _print_time_benchmark(
         max_print_time, _ = _seconds_to_display_time(
             max_time, force_unit=mean_time_unit
         )
-        min_max_print_str = f"\nFastest run: {min_print_time:.2f} {mean_time_unit}. Slowest run: {max_print_time:.2f} {mean_time_unit}."
+        min_max_print_str = f"\n\tFastest run: {min_print_time:.2f} {mean_time_unit}. Slowest run: {max_print_time:.2f} {mean_time_unit}."
     else:
         min_max_print_str = ""
 

--- a/src/basicbenchmark/decorators.py
+++ b/src/basicbenchmark/decorators.py
@@ -35,13 +35,9 @@ def basicbenchmark(n_runs: Optional[int] = None, pre_run: bool = False):
 
         return wrapper
 
-    # when called without parentheses, __call__ will be the function to decorate
-    def __call__(func):  # numpydoc ignore=GL08
-        return decorator(func)
-
-    if callable(n_runs):
-        f = n_runs  # when called without parentheses, n_runs will be the function
-        n_runs = None  # Reset n_runs to default
+    if callable(n_runs):  # when called without parentheses, n_runs will be the function
+        f = n_runs
+        n_runs = None  # reset n_runs to default in this case
         return decorator(f)
 
     # when called with parentheses return the decorator itself

--- a/src/basicbenchmark/decorators.py
+++ b/src/basicbenchmark/decorators.py
@@ -28,10 +28,10 @@ def basicbenchmark(n_runs: Optional[int] = None, pre_run: bool = False):
     def decorator(func):  # numpydoc ignore=GL08
         @wraps(func)
         def wrapper(*args, **kwargs):  # numpydoc ignore=GL08
-            _, return_value = benchmark_stats(
+            result = benchmark_stats(
                 func, args=args, kwargs=kwargs, n_runs=n_runs, pre_run=pre_run
             )
-            return return_value
+            return result["return_value"]
 
         return wrapper
 

--- a/src/basicbenchmark/decorators.py
+++ b/src/basicbenchmark/decorators.py
@@ -1,0 +1,38 @@
+"""
+Decorator function which warps benchmark_stats.
+"""
+
+from functools import wraps
+from typing import Optional
+
+from basicbenchmark.benchmark import benchmark_stats
+
+
+def benchmark_stats_me(n_runs: Optional[int] = None, pre_run: bool = False):
+    """
+    Decorator function for timing the execution of a callable, wraps benchmark_stats.
+
+    Parameters
+    ----------
+    n_runs : int, optional
+        The number of times to run the function. The default is None, which will run the function only 1 time.
+    pre_run : bool, optional
+        If True will run function once before recording times. The default is False.
+
+    Returns
+    -------
+    function
+        The decorator function.
+    """
+
+    def decorator(func):  # numpydoc ignore=GL08
+        @wraps(func)
+        def wrapper(*args, **kwargs):  # numpydoc ignore=GL08
+            _, return_value = benchmark_stats(
+                func, args=args, kwargs=kwargs, n_runs=n_runs, pre_run=pre_run
+            )
+            return return_value
+
+        return wrapper
+
+    return decorator

--- a/src/basicbenchmark/decorators.py
+++ b/src/basicbenchmark/decorators.py
@@ -10,7 +10,7 @@ from basicbenchmark.benchmark import benchmark_stats
 
 def basicbenchmark(n_runs: Optional[int] = None, pre_run: bool = False):
     """
-    Decorator function for timing the execution of a callable, wraps benchmark_stats.
+    Decorator function for timing the execution of a callable.
 
     Parameters
     ----------
@@ -35,4 +35,14 @@ def basicbenchmark(n_runs: Optional[int] = None, pre_run: bool = False):
 
         return wrapper
 
+    # when called without parentheses, __call__ will be the function to decorate
+    def __call__(func):  # numpydoc ignore=GL08
+        return decorator(func)
+
+    if callable(n_runs):
+        f = n_runs  # when called without parentheses, n_runs will be the function
+        n_runs = None  # Reset n_runs to default
+        return decorator(f)
+
+    # when called with parentheses return the decorator itself
     return decorator

--- a/src/basicbenchmark/decorators.py
+++ b/src/basicbenchmark/decorators.py
@@ -8,7 +8,7 @@ from typing import Optional
 from basicbenchmark.benchmark import benchmark_stats
 
 
-def benchmark_stats_me(n_runs: Optional[int] = None, pre_run: bool = False):
+def basicbenchmark(n_runs: Optional[int] = None, pre_run: bool = False):
     """
     Decorator function for timing the execution of a callable, wraps benchmark_stats.
 

--- a/tests/test_basic_benchmark.py
+++ b/tests/test_basic_benchmark.py
@@ -1,6 +1,6 @@
 import pytest
 
-from basicbenchmark.benchmark import benchmark
+from basicbenchmark import benchmark
 
 
 def test_basic_benchmark_with_no_args():

--- a/tests/test_basic_benchmark_stats.py
+++ b/tests/test_basic_benchmark_stats.py
@@ -7,7 +7,7 @@ def test_basic_benchmark_stats_with_no_args():
     def dummy_func():
         pass
 
-    result = benchmark_stats(dummy_func, n_runs=10)
+    result, func_return_value = benchmark_stats(dummy_func, n_runs=10)
     assert isinstance(result["mean"], (int, float))
     assert isinstance(result["stdev"], (int, float))
     assert isinstance(result["min"], (int, float))
@@ -22,7 +22,10 @@ def test_basic_benchmark_stats_with_args():
     def dummy_func(x, y):
         return x + y
 
-    result = benchmark_stats(dummy_func, args=(1, 2), n_runs=10)
+    result, func_return_value = benchmark_stats(dummy_func, args=(1, 2), n_runs=10)
+
+    assert func_return_value == 3
+
     assert isinstance(result["mean"], (int, float))
     assert isinstance(result["stdev"], (int, float))
     assert isinstance(result["min"], (int, float))
@@ -37,7 +40,10 @@ def test_basic_benchmark_stats_with_kwargs():
     def dummy_func(x, y=0):
         return x + y
 
-    result = benchmark_stats(dummy_func, kwargs={"x": 2}, n_runs=10)
+    result, func_return_value = benchmark_stats(dummy_func, kwargs={"x": 2}, n_runs=10)
+
+    assert func_return_value == 2
+
     assert isinstance(result["mean"], (int, float))
     assert isinstance(result["stdev"], (int, float))
     assert isinstance(result["min"], (int, float))
@@ -52,7 +58,7 @@ def test_basic_benchmark_stats_with_pre_run():
     def dummy_func():
         pass
 
-    result = benchmark_stats(dummy_func, pre_run=True, n_runs=10)
+    result, func_return_value = benchmark_stats(dummy_func, pre_run=True, n_runs=10)
     assert isinstance(result["mean"], (int, float))
     assert isinstance(result["stdev"], (int, float))
     assert isinstance(result["min"], (int, float))
@@ -67,7 +73,7 @@ def test_basic_benchmark_stats_with_autorange():
     def dummy_func():
         pass
 
-    result = benchmark_stats(dummy_func, n_runs=1)
+    result, func_return_value = benchmark_stats(dummy_func, n_runs=1)
     assert isinstance(result["mean"], (int, float))
     assert result["stdev"] is None
     assert result["min"] is None

--- a/tests/test_basic_benchmark_stats.py
+++ b/tests/test_basic_benchmark_stats.py
@@ -7,7 +7,7 @@ def test_basic_benchmark_stats_with_no_args():
     def dummy_func():
         pass
 
-    result, func_return_value = benchmark_stats(dummy_func, n_runs=10)
+    result = benchmark_stats(dummy_func, n_runs=10)
     assert isinstance(result["mean"], (int, float))
     assert isinstance(result["stdev"], (int, float))
     assert isinstance(result["min"], (int, float))
@@ -22,9 +22,9 @@ def test_basic_benchmark_stats_with_args():
     def dummy_func(x, y):
         return x + y
 
-    result, func_return_value = benchmark_stats(dummy_func, args=(1, 2), n_runs=10)
+    result = benchmark_stats(dummy_func, args=(1, 2), n_runs=10)
 
-    assert func_return_value == 3
+    assert result["return_value"] == 3
 
     assert isinstance(result["mean"], (int, float))
     assert isinstance(result["stdev"], (int, float))
@@ -40,9 +40,9 @@ def test_basic_benchmark_stats_with_kwargs():
     def dummy_func(x, y=0):
         return x + y
 
-    result, func_return_value = benchmark_stats(dummy_func, kwargs={"x": 2}, n_runs=10)
+    result = benchmark_stats(dummy_func, kwargs={"x": 2}, n_runs=10)
 
-    assert func_return_value == 2
+    assert result["return_value"] == 2
 
     assert isinstance(result["mean"], (int, float))
     assert isinstance(result["stdev"], (int, float))
@@ -58,7 +58,7 @@ def test_basic_benchmark_stats_with_pre_run():
     def dummy_func():
         pass
 
-    result, func_return_value = benchmark_stats(dummy_func, pre_run=True, n_runs=10)
+    result = benchmark_stats(dummy_func, pre_run=True, n_runs=10)
     assert isinstance(result["mean"], (int, float))
     assert isinstance(result["stdev"], (int, float))
     assert isinstance(result["min"], (int, float))
@@ -73,7 +73,7 @@ def test_basic_benchmark_stats_with_autorange():
     def dummy_func():
         pass
 
-    result, func_return_value = benchmark_stats(dummy_func, n_runs=1)
+    result = benchmark_stats(dummy_func, n_runs=1)
     assert isinstance(result["mean"], (int, float))
     assert result["stdev"] is None
     assert result["min"] is None

--- a/tests/test_basic_benchmark_stats.py
+++ b/tests/test_basic_benchmark_stats.py
@@ -1,6 +1,6 @@
 import pytest
 
-from basicbenchmark.benchmark import benchmark_stats
+from basicbenchmark import benchmark_stats
 
 
 def test_basic_benchmark_stats_with_no_args():

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -1,27 +1,27 @@
-from basicbenchmark.decorators import benchmark_stats_me
+from basicbenchmark import basicbenchmark
 
 
-@benchmark_stats_me(n_runs=10)
+@basicbenchmark(n_runs=10)
 def dummy_func_no_args():
     pass
 
 
-@benchmark_stats_me(n_runs=10)
+@basicbenchmark(n_runs=10)
 def dummy_func_with_args(x, y):
     return x + y
 
 
-@benchmark_stats_me(n_runs=10)
+@basicbenchmark(n_runs=10)
 def dummy_func_with_kwargs(x, y=0):
     return x + y
 
 
-@benchmark_stats_me(pre_run=True, n_runs=10)
+@basicbenchmark(pre_run=True, n_runs=10)
 def dummy_func_with_pre_run():
     pass
 
 
-@benchmark_stats_me(n_runs=1)
+@basicbenchmark(n_runs=1)
 def dummy_func_with_autorange():
     pass
 

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -1,0 +1,58 @@
+from basicbenchmark.decorators import benchmark_stats_me
+
+
+@benchmark_stats_me(n_runs=10)
+def dummy_func_no_args():
+    pass
+
+
+@benchmark_stats_me(n_runs=10)
+def dummy_func_with_args(x, y):
+    return x + y
+
+
+@benchmark_stats_me(n_runs=10)
+def dummy_func_with_kwargs(x, y=0):
+    return x + y
+
+
+@benchmark_stats_me(pre_run=True, n_runs=10)
+def dummy_func_with_pre_run():
+    pass
+
+
+@benchmark_stats_me(n_runs=1)
+def dummy_func_with_autorange():
+    pass
+
+
+def test_basic_benchmark_stats_with_no_args(capfd):
+    dummy_func_no_args()
+
+    captured = capfd.readouterr()
+    assert captured.out[:47] == "dummy_func_no_args: 10 runs, mean time per run:"
+
+
+def test_basic_benchmark_stats_with_args(capfd):
+    func_return = dummy_func_with_args(1, 2)
+
+    assert func_return == 3
+
+    captured = capfd.readouterr()
+    assert captured.out[:49] == "dummy_func_with_args: 10 runs, mean time per run:"
+
+
+def test_basic_benchmark_stats_with_kwargs(capfd):
+    func_return = dummy_func_with_kwargs(x=2)
+
+    assert func_return == 2
+
+    captured = capfd.readouterr()
+    assert captured.out[:51] == "dummy_func_with_kwargs: 10 runs, mean time per run:"
+
+
+def test_basic_benchmark_stats_with_pre_run(capfd):
+    dummy_func_with_pre_run()
+
+    captured = capfd.readouterr()
+    assert captured.out[:52] == "dummy_func_with_pre_run: 10 runs, mean time per run:"

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -1,6 +1,16 @@
 from basicbenchmark import basicbenchmark
 
 
+@basicbenchmark
+def dummy_func_with_kwargs_no_params(x, y):
+    return x + y
+
+
+@basicbenchmark()
+def dummy_func_with_kwargs_no_params_in_parens(x, y):
+    return x + y
+
+
 @basicbenchmark(n_runs=10)
 def dummy_func_no_args():
     pass
@@ -26,14 +36,43 @@ def dummy_func_with_autorange():
     pass
 
 
-def test_basic_benchmark_stats_with_no_args(capfd):
+@basicbenchmark(pre_run=True)
+def dummy_func_with_only_pre_run():
+    pass
+
+
+def test_basicbenchmark_decorator_kwargs_no_params_in_parens(capfd):
+    func_return = dummy_func_with_kwargs_no_params_in_parens(x=1, y=2)
+
+    assert func_return == 3
+
+    captured = capfd.readouterr()
+    assert (
+        captured.out[:70]
+        == "dummy_func_with_kwargs_no_params_in_parens: 1 runs, mean time per run:"
+    )
+
+
+def test_basicbenchmark_decorator_kwargs_no_params(capfd):
+    func_return = dummy_func_with_kwargs_no_params(x=1, y=2)
+
+    assert func_return == 3
+
+    captured = capfd.readouterr()
+    assert (
+        captured.out[:60]
+        == "dummy_func_with_kwargs_no_params: 1 runs, mean time per run:"
+    )
+
+
+def test_basicbenchmark_decorator_with_no_args(capfd):
     dummy_func_no_args()
 
     captured = capfd.readouterr()
     assert captured.out[:47] == "dummy_func_no_args: 10 runs, mean time per run:"
 
 
-def test_basic_benchmark_stats_with_args(capfd):
+def test_basicbenchmark_decorator_with_args(capfd):
     func_return = dummy_func_with_args(1, 2)
 
     assert func_return == 3
@@ -42,7 +81,7 @@ def test_basic_benchmark_stats_with_args(capfd):
     assert captured.out[:49] == "dummy_func_with_args: 10 runs, mean time per run:"
 
 
-def test_basic_benchmark_stats_with_kwargs(capfd):
+def test_basicbenchmark_decorator_with_kwargs(capfd):
     func_return = dummy_func_with_kwargs(x=2)
 
     assert func_return == 2
@@ -51,8 +90,17 @@ def test_basic_benchmark_stats_with_kwargs(capfd):
     assert captured.out[:51] == "dummy_func_with_kwargs: 10 runs, mean time per run:"
 
 
-def test_basic_benchmark_stats_with_pre_run(capfd):
+def test_basicbenchmark_decorator_with_pre_run(capfd):
     dummy_func_with_pre_run()
 
     captured = capfd.readouterr()
     assert captured.out[:52] == "dummy_func_with_pre_run: 10 runs, mean time per run:"
+
+
+def test_basicbenchmark_decorator_with_only_pre_run(capfd):
+    dummy_func_with_only_pre_run()
+
+    captured = capfd.readouterr()
+    assert (
+        captured.out[:56] == "dummy_func_with_only_pre_run: 1 runs, mean time per run:"
+    )

--- a/tests/test_print_time_benchmark.py
+++ b/tests/test_print_time_benchmark.py
@@ -18,12 +18,12 @@ def test_prints_benchmark_with_mean_and_stdev_time():
 def test_prints_benchmark_with_mean_stdev_and_min_max_time():
     assert (
         _print_time_benchmark("test_func", 10, 0.002, 0.0001, 0.001, 0.003)
-        == "test_func: 10 runs, mean time per run: 2.00±0.10 ms.\nFastest run: 1.00 ms. Slowest run: 3.00 ms."
+        == "test_func: 10 runs, mean time per run: 2.00±0.10 ms.\n\tFastest run: 1.00 ms. Slowest run: 3.00 ms."
     )
 
 
 def test_prints_benchmark_with_mean_and_min_max_time():
     assert (
         _print_time_benchmark("test_func", 10, 0.002, min_time=0.001, max_time=0.003)
-        == "test_func: 10 runs, mean time per run: 2.00 ms.\nFastest run: 1.00 ms. Slowest run: 3.00 ms."
+        == "test_func: 10 runs, mean time per run: 2.00 ms.\n\tFastest run: 1.00 ms. Slowest run: 3.00 ms."
     )


### PR DESCRIPTION
This PR adds a `@basicbenchmark` decorator to print timing results when calling decorated functions. 

As a part of this functionality the PR also adds the return value of the timed function to the dictionary returned by `benchmark_stats` function.